### PR TITLE
feat: add independent Coach Digest evaluation

### DIFF
--- a/docs/evals/coach_narrative_test_and_eval_guide.md
+++ b/docs/evals/coach_narrative_test_and_eval_guide.md
@@ -24,6 +24,7 @@ source .venv/bin/activate        # Bash/Zsh
 | Coach Digest Validations (groundedness, non-circularity, raw value leakage, current-state claims, length) | Unit tests | No | `tests/coach/test_weekly_digest.py` |
 | Coach Digest Validations batch report over a real Weekly Drift Detection output set | Eval | No | `src/evals/coach_digest_validations.py` |
 | Coach Digest Evals (correctness, specificity, non-prescriptive tone, tension honesty) | Eval | **Yes (paid)** | `src/evals/coach_narrative_judge.py` |
+| Coach Digest Drift/control comparison | Study | **Yes (paid generation and AI review)** | `scripts/experiments/run_coach_drift_control_eval.py`, `src/evals/coach_drift_control_report.py` |
 
 Coach Digest Validations are mechanical code checks, not human validation.
 Coach Digest Evals produce **AI evaluation, not human validation**. Future
@@ -59,7 +60,9 @@ mocked calls:
 
 ```sh
 uv run pytest tests/evals/test_coach_digest_validations.py \
-              tests/evals/test_coach_narrative_judge.py
+              tests/evals/test_coach_narrative_judge.py \
+              tests/evals/test_coach_drift_control_report.py \
+              tests/experiments/test_run_coach_drift_control_eval.py
 ```
 
 Lint and type-check touched code when you change it:
@@ -159,6 +162,24 @@ uv run python -m src.evals.coach_narrative_judge \
   --execute
 ```
 
+Use `--judge-provider openai` or `--judge-provider gemini` to select the
+evaluator provider. Use `--judge-model` to select a model for that provider.
+When the selected provider differs from `TWINKL_COACH_PROVIDER`, it uses its
+provider default if `--judge-model` is absent. For example, this command
+evaluates OpenAI-generated responses with Gemini:
+
+```sh
+uv run python -m src.evals.coach_narrative_judge \
+  --manifest logs/experiments/reports/coach_digest_sample_20260824/judge_sample_manifest.json \
+  --judge-provider gemini \
+  --out logs/experiments/reports/coach_digest_evals_cross_provider \
+  --execute
+```
+
+The output records both the generator model and evaluator model when the
+manifest records the generator. It reports the same-model limit only when both
+models match.
+
 Targets: mean > 3.5/5 per dimension. Any response scoring below 3 on any
 dimension is flagged for human review. Report and doc lines label these scores
 as AI evaluation, not human validation. The report keeps each response score,
@@ -167,10 +188,67 @@ request latency.
 
 ---
 
+## 4. Drift/control study
+
+This study compares Coach Digest responses for known Drift records with matched
+control targets. A control target comes from a Persona with no known Drift in
+the complete development results. The match uses the historical split, Journal
+Entry count, and reviewed week count.
+
+First, build the deterministic target catalog. This command makes no provider
+calls:
+
+```sh
+uv run python scripts/experiments/run_coach_drift_control_eval.py
+```
+
+Review `logs/experiments/reports/coach_digest_drift_control/targets.json`.
+Then generate the missing Weekly Drift Detection and Coach Digest responses.
+This command makes paid provider calls:
+
+```sh
+uv run python scripts/experiments/run_coach_drift_control_eval.py \
+  --resume --execute
+```
+
+`--resume` keeps completed target IDs and does not repeat their paid calls. The
+runner stops if generated outputs exist but the matching manifest is absent.
+It also stops if a resumed run selects a different Coach Digest generator
+model.
+
+Run Coach Digest Evals with an independent provider:
+
+```sh
+uv run python -m src.evals.coach_narrative_judge \
+  --manifest logs/experiments/reports/coach_digest_drift_control/judge_sample_manifest.json \
+  --judge-provider gemini \
+  --out logs/experiments/reports/coach_digest_drift_control/evals \
+  --execute
+```
+
+Build the comparison report. This command makes no provider calls:
+
+```sh
+uv run python -m src.evals.coach_drift_control_report \
+  --manifest logs/experiments/reports/coach_digest_drift_control/judge_sample_manifest.json \
+  --eval-metrics logs/experiments/reports/coach_digest_drift_control/evals/metrics.json \
+  --out logs/experiments/reports/coach_digest_drift_control/comparison
+```
+
+The report compares Coach Digest Validation pass rates and Coach Digest Eval
+means for Drift and control targets. It also reports the known Drift delivery
+state and the input history for each target type. The known Drift records are
+AI-reviewed synthetic development data. They are not human ground truth.
+
+---
+
 ## Provenance and honesty notes
 
 - Record the public bundle source, sample manifest, evaluator provider/model, and row/
   sample counts with every committed report.
+- Record the Drift episode Parquet, case outcome Parquet, wrangled Journal Entry
+  directory, source hashes, target seed, and target catalog for the
+  Drift/control study.
 - Do not treat AI evaluation scores as human validation. State the source
   wherever it affects the conclusion.
 - Build the deployed-Persona manifest from the rebuilt public scenario bundles.

--- a/scripts/experiments/run_coach_drift_control_eval.py
+++ b/scripts/experiments/run_coach_drift_control_eval.py
@@ -1,0 +1,610 @@
+"""Select Drift and control targets and optionally generate Coach Digest responses.
+
+The default command is a dry run. It writes a deterministic target catalog and
+makes no provider calls. ``--execute`` runs Weekly Drift Detection and Coach
+Digest generation for targets that are not already in the manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import random
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+import polars as pl
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from src.coach.llm_client import (  # noqa: E402
+    build_llm_complete,
+    resolve_coach_model,
+)
+from src.coach.schemas import LLMCallMetrics, WeeklyDigest  # noqa: E402
+from src.coach.weekly_drift_runtime import run_weekly_drift_coach_cycle  # noqa: E402
+from src.wrangling.parse_wrangled_data import parse_wrangled_file  # noqa: E402
+
+DEFAULT_RESULTS_DIR = Path(
+    "logs/experiments/artifacts/"
+    "twinkl_qtwz_complete_development_review_20260714/results"
+)
+DEFAULT_EPISODES = DEFAULT_RESULTS_DIR / "complete_development_drift_episodes.parquet"
+DEFAULT_CASE_OUTCOMES = (
+    DEFAULT_RESULTS_DIR / "complete_development_case_outcomes.parquet"
+)
+DEFAULT_REPORT_DIR = Path(
+    "logs/experiments/reports/coach_digest_drift_control"
+)
+DEFAULT_PARQUET = Path(
+    "logs/exports/weekly_digests/coach_digest_drift_control.parquet"
+)
+DEFAULT_OUTPUT_DIR = Path("logs/exports/weekly_drift_coach/drift_control")
+DEFAULT_SEED = 20260823
+
+TargetGroup = Literal["drift", "control"]
+
+
+@dataclass(frozen=True)
+class EvalTarget:
+    """One Persona cutoff for the Drift/control Coach Digest study."""
+
+    target_id: str
+    persona_id: str
+    end_date: str
+    group: TargetGroup
+    historical_split: str
+    entry_count: int
+    reviewed_week_count: int
+    dimension: str | None = None
+    delivery_state: str | None = None
+    episode_id: str | None = None
+    matched_to: str | None = None
+    match_quality: str = "exact"
+
+
+def _entry_count_bucket(entry_count: int) -> str:
+    if entry_count <= 6:
+        return "at_most_6"
+    if entry_count <= 9:
+        return "7_to_9"
+    return "10_to_12"
+
+
+def _week_end(raw: str) -> date:
+    value = date.fromisoformat(raw)
+    return value + timedelta(days=6 - value.weekday())
+
+
+def _persona_week_ends(wrangled_dir: Path, persona_id: str) -> list[str]:
+    path = wrangled_dir / f"persona_{persona_id}.md"
+    _profile, entries, _warnings = parse_wrangled_file(path)
+    week_ends = {_week_end(str(entry["date"])) for entry in entries}
+    return [value.isoformat() for value in sorted(week_ends)]
+
+
+def _reviewed_week_count(week_ends: list[str], end_date: str) -> int:
+    cutoff = _week_end(end_date).isoformat()
+    return sum(1 for week_end in week_ends if week_end <= cutoff)
+
+
+def load_drift_targets(
+    episodes_path: Path,
+    case_outcomes_path: Path,
+    wrangled_dir: Path,
+) -> list[EvalTarget]:
+    """Build one target for each known development-set Drift."""
+    episodes = pl.read_parquet(episodes_path)
+    cases = pl.read_parquet(case_outcomes_path)
+    case_index = {
+        (row["persona_id"], row["dimension"]): row for row in cases.to_dicts()
+    }
+    week_ends_by_persona: dict[str, list[str]] = {}
+    targets: list[EvalTarget] = []
+    for row in episodes.to_dicts():
+        persona_id = str(row["persona_id"])
+        dimension = str(row["dimension"])
+        case = case_index[(persona_id, dimension)]
+        if persona_id not in week_ends_by_persona:
+            week_ends_by_persona[persona_id] = _persona_week_ends(
+                wrangled_dir,
+                persona_id,
+            )
+        week_ends = week_ends_by_persona[persona_id]
+        end_date = str(row["confirmation_date"])
+        episode_id = str(row["episode_id"])
+        targets.append(
+            EvalTarget(
+                target_id=f"drift:{episode_id}",
+                persona_id=persona_id,
+                end_date=end_date,
+                group="drift",
+                historical_split=str(case["historical_split"]),
+                entry_count=int(case["entry_count"]),
+                reviewed_week_count=_reviewed_week_count(week_ends, end_date),
+                dimension=dimension,
+                delivery_state=str(row["delivery_state"]),
+                episode_id=episode_id,
+            )
+        )
+    return sorted(targets, key=lambda target: target.target_id)
+
+
+def _candidate_ladder(
+    *,
+    by_stratum: dict[tuple[str, str], list[dict[str, Any]]],
+    by_split: dict[str, list[dict[str, Any]]],
+    pool: list[dict[str, Any]],
+    split: str,
+    bucket: str,
+    used_personas: set[str],
+) -> tuple[list[dict[str, Any]], str]:
+    def available(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return [row for row in rows if row["persona_id"] not in used_personas]
+
+    exact = available(by_stratum.get((split, bucket), []))
+    if exact:
+        return exact, "exact"
+    same_bucket = available(
+        [
+            row
+            for (_split, row_bucket), rows in by_stratum.items()
+            if row_bucket == bucket
+            for row in rows
+        ]
+    )
+    if same_bucket:
+        return same_bucket, "split_relaxed"
+    same_split = available(by_split.get(split, []))
+    if same_split:
+        return same_split, "entry_count_relaxed"
+    return available(pool), "unmatched"
+
+
+def sample_control_targets(
+    case_outcomes_path: Path,
+    episodes_path: Path,
+    drift_targets: list[EvalTarget],
+    wrangled_dir: Path,
+    *,
+    seed: int = DEFAULT_SEED,
+) -> list[EvalTarget]:
+    """Match one no-Drift Persona cutoff to each Drift target."""
+    episodes = pl.read_parquet(episodes_path)
+    drift_personas = set(episodes["persona_id"].to_list())
+    cases = pl.read_parquet(case_outcomes_path)
+    pool = [
+        row
+        for row in cases.to_dicts()
+        if row["persona_id"] not in drift_personas and row["has_drift"] is False
+    ]
+
+    by_stratum: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    by_split: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in pool:
+        bucket = _entry_count_bucket(int(row["entry_count"]))
+        by_stratum[(str(row["historical_split"]), bucket)].append(row)
+        by_split[str(row["historical_split"])].append(row)
+
+    rng = random.Random(seed)
+    for rows in by_stratum.values():
+        rng.shuffle(rows)
+
+    used_personas: set[str] = set()
+    week_ends_by_persona: dict[str, list[str]] = {}
+    controls: list[EvalTarget] = []
+    for drift_target in drift_targets:
+        candidates, match_quality = _candidate_ladder(
+            by_stratum=by_stratum,
+            by_split=by_split,
+            pool=pool,
+            split=drift_target.historical_split,
+            bucket=_entry_count_bucket(drift_target.entry_count),
+            used_personas=used_personas,
+        )
+        if not candidates:
+            continue
+        same_dimension = [
+            row for row in candidates if row["dimension"] == drift_target.dimension
+        ]
+        chosen = rng.choice(same_dimension or candidates)
+        persona_id = str(chosen["persona_id"])
+        if persona_id not in week_ends_by_persona:
+            week_ends_by_persona[persona_id] = _persona_week_ends(
+                wrangled_dir,
+                persona_id,
+            )
+        week_ends = week_ends_by_persona[persona_id]
+        if not week_ends:
+            continue
+        used_personas.add(persona_id)
+        end_date = min(
+            week_ends,
+            key=lambda value: (
+                abs(
+                    _reviewed_week_count(week_ends, value)
+                    - drift_target.reviewed_week_count
+                ),
+                value,
+            ),
+        )
+        controls.append(
+            EvalTarget(
+                target_id=f"control:{drift_target.episode_id}:{persona_id}",
+                persona_id=persona_id,
+                end_date=end_date,
+                group="control",
+                historical_split=str(chosen["historical_split"]),
+                entry_count=int(chosen["entry_count"]),
+                reviewed_week_count=_reviewed_week_count(week_ends, end_date),
+                dimension=str(chosen["dimension"]),
+                matched_to=drift_target.episode_id,
+                match_quality=match_quality,
+            )
+        )
+    return controls
+
+
+def build_targets(
+    *,
+    episodes_path: Path,
+    case_outcomes_path: Path,
+    wrangled_dir: Path,
+    group: str,
+    seed: int,
+    limit: int | None,
+) -> list[EvalTarget]:
+    drift_targets = load_drift_targets(
+        episodes_path,
+        case_outcomes_path,
+        wrangled_dir,
+    )
+    if limit is not None:
+        drift_targets = drift_targets[:limit]
+    controls = (
+        sample_control_targets(
+            case_outcomes_path,
+            episodes_path,
+            drift_targets,
+            wrangled_dir,
+            seed=seed,
+        )
+        if group in {"control", "both"}
+        else []
+    )
+    if group == "control":
+        drift_targets = []
+    return drift_targets + controls
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _directory_sha256(path: Path) -> str:
+    """Hash each wrangled Markdown file name and content in order."""
+    digest = hashlib.sha256()
+    for file_path in sorted(path.glob("persona_*.md")):
+        digest.update(file_path.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _target_catalog(
+    targets: list[EvalTarget],
+    *,
+    seed: int,
+    episodes_path: Path,
+    case_outcomes_path: Path,
+    wrangled_dir: Path,
+) -> dict[str, Any]:
+    target_ids = [target.target_id for target in targets]
+    if len(target_ids) != len(set(target_ids)):
+        raise ValueError("Target selection produced duplicate target IDs.")
+    return {
+        "schema_version": "coach-digest-drift-control-targets-v1",
+        "seed": seed,
+        "sources": {
+            "episodes": {"path": str(episodes_path), "sha256": _sha256(episodes_path)},
+            "case_outcomes": {
+                "path": str(case_outcomes_path),
+                "sha256": _sha256(case_outcomes_path),
+            },
+            "wrangled": {
+                "path": str(wrangled_dir),
+                "sha256": _directory_sha256(wrangled_dir),
+            },
+        },
+        "targets": [asdict(target) for target in targets],
+    }
+
+
+def merge_target_catalog(
+    path: Path,
+    catalog: dict[str, Any],
+    *,
+    resume: bool,
+) -> dict[str, Any]:
+    """Keep earlier targets in a catalog that the same inputs can reproduce."""
+    if not resume or not path.exists():
+        return catalog
+    existing = json.loads(path.read_text())
+    if (
+        existing.get("schema_version") != catalog["schema_version"]
+        or existing.get("seed") != catalog["seed"]
+        or existing.get("sources") != catalog["sources"]
+    ):
+        raise ValueError(
+            "Existing target catalog uses a different schema, inputs, or seed."
+        )
+    merged: dict[str, dict[str, Any]] = {}
+    for item in existing.get("targets", []):
+        target_id = str(item["target_id"])
+        if target_id in merged:
+            raise ValueError(f"Duplicate target catalog ID: {target_id}")
+        merged[target_id] = item
+    merged.update({item["target_id"]: item for item in catalog["targets"]})
+    return {**catalog, "targets": [merged[key] for key in sorted(merged)]}
+
+
+def _manifest_index(path: Path, *, resume: bool) -> dict[str, dict[str, Any]]:
+    if not resume or not path.exists():
+        return {}
+    items = json.loads(path.read_text())
+    manifest: dict[str, dict[str, Any]] = {}
+    for item in items:
+        target_id = item.get("target", {}).get("target_id")
+        if not target_id:
+            raise ValueError("Manifest record has no target ID.")
+        target_id = str(target_id)
+        if target_id in manifest:
+            raise ValueError(f"Duplicate manifest target ID: {target_id}")
+        manifest[target_id] = item
+    return manifest
+
+
+def _write_manifest(path: Path, manifest: dict[str, dict[str, Any]]) -> None:
+    """Write completed target records after each paid generation step."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    temporary_path.write_text(
+        json.dumps([manifest[key] for key in sorted(manifest)], indent=2) + "\n"
+    )
+    temporary_path.replace(path)
+
+
+def _canonical_sha256(value: object) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _target_output_dir(output_dir: Path, target_id: str) -> Path:
+    suffix = hashlib.sha256(target_id.encode("utf-8")).hexdigest()[:16]
+    return output_dir / f"target_{suffix}"
+
+
+def _manifest_entry(
+    digest: WeeklyDigest,
+    target: EvalTarget,
+    generator_model: str,
+    call_metrics: list[LLMCallMetrics],
+    output_paths: dict[str, str],
+) -> dict[str, Any] | None:
+    if digest.coach_narrative is None or digest.validation is None:
+        return None
+    digest_payload = digest.model_dump(
+        mode="json",
+        exclude={"coach_narrative", "validation"},
+    )
+    narrative_payload = digest.coach_narrative.model_dump(mode="json")
+    return {
+        "digest": digest_payload,
+        "narrative": narrative_payload,
+        "validation": {
+            **digest.validation.model_dump(mode="json"),
+            "all_passed": digest.validation.all_passed,
+        },
+        "generator_model": generator_model,
+        "target": asdict(target),
+        "provenance": {
+            "weekly_drift_input_sha256": _canonical_sha256(digest_payload),
+            "coach_response_sha256": _canonical_sha256(narrative_payload),
+            "call_metrics": [metric.model_dump(mode="json") for metric in call_metrics],
+            "output_paths": output_paths,
+        },
+    }
+
+
+async def generate_missing_targets(
+    targets: list[EvalTarget],
+    existing: dict[str, dict[str, Any]],
+    *,
+    parquet_path: Path,
+    output_dir: Path,
+    wrangled_dir: Path,
+    manifest_path: Path | None = None,
+) -> dict[str, dict[str, Any]]:
+    pending = [target for target in targets if target.target_id not in existing]
+    if not pending:
+        return existing
+
+    provider, model = resolve_coach_model()
+    generator_model = f"{provider}:{model}"
+    previous_models = {
+        str(entry["generator_model"])
+        for entry in existing.values()
+        if entry.get("generator_model")
+    }
+    if previous_models and previous_models != {generator_model}:
+        raise ValueError("Resume uses a different Coach Digest generator model.")
+
+    call_metrics: list[LLMCallMetrics] = []
+    coach_llm_complete = build_llm_complete(call_metrics=call_metrics)
+    if coach_llm_complete is None:
+        raise SystemExit("No Coach Digest provider is available. Check its API key.")
+
+    for index, target in enumerate(pending, start=1):
+        print(f"[{index}/{len(pending)}] {target.target_id}", flush=True)
+        metrics_start = len(call_metrics)
+        digest, output_paths = await run_weekly_drift_coach_cycle(
+            persona_id=target.persona_id,
+            wrangled_dir=wrangled_dir,
+            output_dir=_target_output_dir(output_dir, target.target_id),
+            parquet_path=parquet_path,
+            end_date=target.end_date,
+            coach_llm_complete=coach_llm_complete,
+            attach_failed_validation=True,
+        )
+        target_metrics = call_metrics[metrics_start:]
+        for attempt, metric in enumerate(target_metrics, start=1):
+            metric.call_label = f"coach_generation:{target.target_id}:attempt_{attempt}"
+        entry = _manifest_entry(
+            digest,
+            target,
+            generator_model,
+            target_metrics,
+            output_paths,
+        )
+        if entry is None:
+            print(f"[warn] {target.target_id}: no response to evaluate", flush=True)
+            continue
+        existing[target.target_id] = entry
+        if manifest_path is not None:
+            _write_manifest(manifest_path, existing)
+    return existing
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Select and optionally run the Coach Digest Drift/control study."
+    )
+    parser.add_argument("--episodes-parquet", type=Path, default=DEFAULT_EPISODES)
+    parser.add_argument(
+        "--case-outcomes-parquet",
+        type=Path,
+        default=DEFAULT_CASE_OUTCOMES,
+    )
+    parser.add_argument("--wrangled-dir", type=Path, default=Path("logs/wrangled"))
+    parser.add_argument("--parquet-path", type=Path, default=DEFAULT_PARQUET)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--manifest-out",
+        type=Path,
+        default=DEFAULT_REPORT_DIR / "judge_sample_manifest.json",
+    )
+    parser.add_argument(
+        "--targets-out",
+        type=Path,
+        default=DEFAULT_REPORT_DIR / "targets.json",
+    )
+    parser.add_argument(
+        "--group",
+        choices=["drift", "control", "both"],
+        default="both",
+    )
+    parser.add_argument("--limit", type=_positive_int, default=None)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Authorize paid Weekly Drift Reviewer and Coach Digest calls.",
+    )
+    return parser
+
+
+def _positive_int(raw: str) -> int:
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    args = _build_parser().parse_args(argv)
+    targets = build_targets(
+        episodes_path=args.episodes_parquet,
+        case_outcomes_path=args.case_outcomes_parquet,
+        wrangled_dir=args.wrangled_dir,
+        group=args.group,
+        seed=args.seed,
+        limit=args.limit,
+    )
+    generated_outputs_exist = (
+        args.parquet_path.exists()
+        or args.manifest_out.exists()
+        or (
+            args.output_dir.exists()
+            and any(args.output_dir.iterdir())
+        )
+    )
+    if args.execute and generated_outputs_exist and not args.resume:
+        raise ValueError(
+            "Generated outputs exist. Use --resume or select new output paths."
+        )
+    if (
+        args.execute
+        and args.resume
+        and generated_outputs_exist
+        and not args.manifest_out.exists()
+    ):
+        raise ValueError("Resume needs the existing manifest for generated outputs.")
+    catalog = _target_catalog(
+        targets,
+        seed=args.seed,
+        episodes_path=args.episodes_parquet,
+        case_outcomes_path=args.case_outcomes_parquet,
+        wrangled_dir=args.wrangled_dir,
+    )
+    catalog = merge_target_catalog(args.targets_out, catalog, resume=args.resume)
+    args.targets_out.parent.mkdir(parents=True, exist_ok=True)
+    args.targets_out.write_text(json.dumps(catalog, indent=2) + "\n")
+
+    counts = {
+        group: sum(target.group == group for target in targets)
+        for group in ("drift", "control")
+    }
+    print(f"Drift targets: {counts['drift']}")
+    print(f"Control targets: {counts['control']}")
+    print(f"Targets: {args.targets_out}")
+    if not args.execute:
+        print("[dry run] No provider calls made.")
+        return 0
+
+    manifest = _manifest_index(args.manifest_out, resume=args.resume)
+    manifest = asyncio.run(
+        generate_missing_targets(
+            targets,
+            manifest,
+            parquet_path=args.parquet_path,
+            output_dir=args.output_dir,
+            wrangled_dir=args.wrangled_dir,
+            manifest_path=args.manifest_out,
+        )
+    )
+    _write_manifest(args.manifest_out, manifest)
+    print(f"Manifest responses: {len(manifest)}")
+    print(f"Manifest: {args.manifest_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/coach/llm_client.py
+++ b/src/coach/llm_client.py
@@ -30,6 +30,10 @@ DEFAULT_OPENAI_SERVICE_TIER = "default"
 DEFAULT_GEMINI_MODEL = "gemini-3.5-flash"
 DEFAULT_TIMEOUT_SECONDS = 60.0
 DEFAULT_MAX_OUTPUT_TOKENS = 2048
+DEFAULT_MODELS = {
+    "openai": DEFAULT_OPENAI_MODEL,
+    "gemini": DEFAULT_GEMINI_MODEL,
+}
 OPENAI_LUNA_PRICING_SOURCE = (
     "https://developers.openai.com/api/docs/models/gpt-5.6-luna"
 )
@@ -173,6 +177,30 @@ def _unwrap_json_schema(response_format: dict | None) -> dict | None:
     return schema if isinstance(schema, dict) else None
 
 
+def resolve_coach_model(
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+) -> tuple[str, str]:
+    """Return the provider and model that ``build_llm_complete`` will use.
+
+    If the selected provider differs from ``TWINKL_COACH_PROVIDER``, it does not
+    reuse ``TWINKL_COACH_MODEL``. It uses the selected provider's default model.
+    An explicit ``model`` overrides that default.
+    """
+    configured_provider = os.environ.get("TWINKL_COACH_PROVIDER", "openai")
+    configured_provider = configured_provider.strip().lower()
+    resolved_provider = (provider or configured_provider).strip().lower()
+    default_model = DEFAULT_MODELS.get(resolved_provider, DEFAULT_OPENAI_MODEL)
+    if model is not None:
+        resolved_model = model
+    elif provider is None or resolved_provider == configured_provider:
+        resolved_model = os.environ.get("TWINKL_COACH_MODEL", default_model)
+    else:
+        resolved_model = default_model
+    return resolved_provider, resolved_model
+
+
 def _build_openai_llm_complete(
     *,
     model: str | None,
@@ -183,7 +211,7 @@ def _build_openai_llm_complete(
     if not os.environ.get("OPENAI_API_KEY"):
         return None
 
-    resolved_model = model or os.environ.get("TWINKL_COACH_MODEL", DEFAULT_OPENAI_MODEL)
+    resolved_model = model or DEFAULT_OPENAI_MODEL
 
     async def llm_complete(
         prompt: str,
@@ -251,7 +279,7 @@ def _build_gemini_llm_complete(
     if not api_key:
         return None
 
-    resolved_model = model or os.environ.get("TWINKL_COACH_MODEL", DEFAULT_GEMINI_MODEL)
+    resolved_model = model or DEFAULT_GEMINI_MODEL
 
     def _generate(
         prompt: str,
@@ -350,9 +378,10 @@ def build_llm_complete(
     defaulting to ``openai``. Returns ``None`` when the provider's API key is
     missing or the provider is unrecognised, so the demo stays runnable offline.
     """
-    resolved_provider = (
-        provider or os.environ.get("TWINKL_COACH_PROVIDER", "openai")
-    ).strip().lower()
+    resolved_provider, resolved_model = resolve_coach_model(
+        provider=provider,
+        model=model,
+    )
     resolved_timeout = timeout if timeout is not None else DEFAULT_TIMEOUT_SECONDS
     resolved_max_tokens = (
         max_output_tokens
@@ -369,7 +398,7 @@ def build_llm_complete(
         return None
 
     return builder(
-        model=model,
+        model=resolved_model,
         timeout=resolved_timeout,
         max_output_tokens=resolved_max_tokens,
         call_metrics=call_metrics,

--- a/src/coach/weekly_drift_runtime.py
+++ b/src/coach/weekly_drift_runtime.py
@@ -224,8 +224,15 @@ async def run_weekly_drift_coach_cycle(
     end_date: str | None = None,
     reviewer: WeeklyDriftReviewerFn | None = None,
     coach_llm_complete=None,
+    attach_failed_validation: bool = False,
 ) -> tuple[WeeklyDigest, dict[str, str]]:
-    """Run Weekly Drift Detection and optionally produce a Coach Digest response."""
+    """Run Weekly Drift Detection and optionally produce a Coach Digest response.
+
+    Product callers drop a response that fails Coach Digest Validations. An
+    offline evaluation can set ``attach_failed_validation`` to measure those
+    failures. Evaluation callers must check ``digest.validation.all_passed``
+    before they use the response as a valid Coach Digest response.
+    """
     wrangled_path = Path(wrangled_dir)
     output_path = Path(output_dir)
     synthetic_profile, entries = _load_runtime_input(
@@ -321,7 +328,7 @@ async def run_weekly_drift_coach_cycle(
             coach_llm_complete,
         )
         if (
-            coach_diagnostic.accepted
+            (coach_diagnostic.accepted or attach_failed_validation)
             and coach_diagnostic.narrative is not None
             and coach_diagnostic.validation is not None
         ):

--- a/src/evals/coach_drift_control_report.py
+++ b/src/evals/coach_drift_control_report.py
@@ -1,0 +1,452 @@
+"""Compare Coach Digest results for known Drift and matched control targets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CHECK_NAMES = (
+    "groundedness",
+    "non_circularity",
+    "value_leakage",
+    "state_claims",
+    "length",
+)
+SCORE_DIMENSIONS = (
+    "correctness",
+    "specificity",
+    "non_prescriptive_tone",
+    "tension_honesty",
+)
+GROUPS = ("drift", "control")
+
+
+def wilson_interval(
+    passed: int,
+    total: int,
+    z: float = 1.96,
+) -> tuple[float, float]:
+    """Return a Wilson score interval that stays between zero and one."""
+    if total == 0:
+        return (0.0, 0.0)
+    rate = passed / total
+    denominator = 1 + z**2 / total
+    center = (rate + z**2 / (2 * total)) / denominator
+    margin = (
+        z * math.sqrt(rate * (1 - rate) / total + z**2 / (4 * total**2))
+    ) / denominator
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+@dataclass
+class RateCell:
+    passed: int = 0
+    total: int = 0
+
+    def to_dict(self) -> dict[str, object]:
+        low, high = wilson_interval(self.passed, self.total)
+        rate = self.passed / self.total if self.total else 0.0
+        return {
+            "passed": self.passed,
+            "total": self.total,
+            "rate": round(rate, 3),
+            "ci95": [round(low, 3), round(high, 3)],
+        }
+
+
+@dataclass
+class ScoreCell:
+    values: list[int] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        mean = sum(self.values) / len(self.values) if self.values else 0.0
+        return {"n": len(self.values), "mean": round(mean, 3)}
+
+
+def _manifest_rows(manifest: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in manifest:
+        digest = item.get("digest") or {}
+        target = item.get("target") or {}
+        validation = item.get("validation") or {}
+        target_id = str(
+            target.get("target_id")
+            or f"{digest.get('persona_id')}:{digest.get('week_end')}"
+        )
+        if target_id in seen:
+            raise ValueError(f"Duplicate manifest target: {target_id}")
+        seen.add(target_id)
+        checks = {
+            str(check["name"]): bool(check["passed"])
+            for check in validation.get("checks", [])
+        }
+        rows.append(
+            {
+                "sample_id": target_id,
+                "persona_id": digest.get("persona_id"),
+                "week_end": digest.get("week_end"),
+                "group": target.get("group"),
+                "known_delivery_state": target.get("delivery_state"),
+                "match_quality": target.get("match_quality"),
+                "reviewed_week_count": target.get("reviewed_week_count"),
+                "response_mode": digest.get("response_mode"),
+                "n_entries": digest.get("n_entries"),
+                "n_evidence": len(digest.get("evidence") or []),
+                "checks": checks,
+                "all_passed": bool(checks)
+                and all(checks.get(name) is True for name in CHECK_NAMES),
+            }
+        )
+    return rows
+
+
+def _attach_eval_results(
+    rows: list[dict[str, Any]],
+    eval_metrics: dict[str, Any],
+) -> None:
+    sample_results = eval_metrics.get("sample_results") or []
+    by_sample: dict[str, dict[str, Any]] = {}
+    for result in sample_results:
+        sample_id = str(result["sample_id"])
+        if sample_id in by_sample:
+            raise ValueError(f"Duplicate AI evaluation result: {sample_id}")
+        by_sample[sample_id] = result
+    row_ids = {str(row["sample_id"]) for row in rows}
+    unmatched = sorted(set(by_sample) - row_ids)
+    if unmatched:
+        raise ValueError(
+            "AI evaluation results do not match the manifest: "
+            + ", ".join(unmatched)
+        )
+    for row in rows:
+        result = by_sample.get(row["sample_id"])
+        row["eval_result"] = (
+            result if result and result.get("status") == "scored" else None
+        )
+
+
+def _rates_by(
+    rows: list[dict[str, Any]],
+    group_key: str,
+) -> dict[str, dict[str, dict[str, object]]]:
+    cells: dict[str, dict[str, RateCell]] = defaultdict(
+        lambda: defaultdict(RateCell)
+    )
+    for row in rows:
+        group = row.get(group_key)
+        if group is None:
+            continue
+        for name in CHECK_NAMES:
+            if name not in row["checks"]:
+                continue
+            cell = cells[str(group)][name]
+            cell.total += 1
+            cell.passed += int(row["checks"][name])
+    return {
+        group: {name: cell.to_dict() for name, cell in checks.items()}
+        for group, checks in cells.items()
+    }
+
+
+def _scores_by(
+    rows: list[dict[str, Any]],
+    group_key: str,
+) -> dict[str, dict[str, dict[str, object]]]:
+    cells: dict[str, dict[str, ScoreCell]] = defaultdict(
+        lambda: defaultdict(ScoreCell)
+    )
+    for row in rows:
+        group = row.get(group_key)
+        result = row.get("eval_result")
+        if group is None or result is None:
+            continue
+        for dimension in SCORE_DIMENSIONS:
+            if dimension in result:
+                cells[str(group)][dimension].values.append(int(result[dimension]))
+    return {
+        group: {name: cell.to_dict() for name, cell in scores.items()}
+        for group, scores in cells.items()
+    }
+
+
+def _counts_by(
+    rows: list[dict[str, Any]],
+    group_key: str,
+    value_key: str,
+) -> dict[str, dict[str, int]]:
+    counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in rows:
+        group = row.get(group_key)
+        if group is not None:
+            counts[str(group)][str(row.get(value_key))] += 1
+    return {group: dict(values) for group, values in counts.items()}
+
+
+def _history_summary(
+    rows: list[dict[str, Any]],
+) -> dict[str, dict[str, float | int]]:
+    """Summarize inputs that can cause a false difference between groups."""
+    result: dict[str, dict[str, float | int]] = {}
+    for group in GROUPS:
+        group_rows = [row for row in rows if row.get("group") == group]
+        if not group_rows:
+            continue
+        result[group] = {"n": len(group_rows)}
+        for key in ("n_entries", "n_evidence", "reviewed_week_count"):
+            values = [
+                float(row[key])
+                for row in group_rows
+                if row.get(key) is not None
+            ]
+            result[group][f"mean_{key}"] = (
+                round(sum(values) / len(values), 3) if values else 0.0
+            )
+    return result
+
+
+def build_report(
+    manifest: list[dict[str, Any]],
+    eval_metrics: dict[str, Any],
+    *,
+    manifest_source: str = "",
+    eval_source: str = "",
+) -> dict[str, Any]:
+    """Build the complete Drift/control comparison."""
+    rows = _manifest_rows(manifest)
+    _attach_eval_results(rows, eval_metrics)
+    generator_models = {
+        str(item["generator_model"])
+        for item in manifest
+        if item.get("generator_model")
+    }
+    if len(generator_models) > 1:
+        raise ValueError("Manifest uses multiple Coach Digest generator models.")
+    generator_model = (
+        next(iter(generator_models)) if len(generator_models) == 1 else None
+    )
+    evaluator_model = eval_metrics.get("judge_model")
+    eval_generator_model = eval_metrics.get("generator_model")
+    if (
+        generator_model is not None
+        and eval_generator_model is not None
+        and generator_model != eval_generator_model
+    ):
+        raise ValueError("Evaluator metrics use a different generator model.")
+    return {
+        "eval": "coach_digest_drift_control_comparison",
+        "source": "mechanical_code_checks_and_ai_review",
+        "note": (
+            "Coach Digest Validations are code checks. Coach Digest Evals are AI "
+            "review. Neither result is human validation."
+        ),
+        "manifest_source": manifest_source,
+        "eval_source": eval_source,
+        "generator_model": generator_model,
+        "evaluator_model": evaluator_model,
+        "cross_provider": (
+            generator_model.split(":", 1)[0]
+            != str(evaluator_model).split(":", 1)[0]
+            if generator_model is not None and evaluator_model is not None
+            else None
+        ),
+        "self_evaluation": (
+            generator_model == evaluator_model
+            if generator_model is not None and evaluator_model is not None
+            else None
+        ),
+        "n_rows": len(rows),
+        "n_by_group": {
+            group: sum(row.get("group") == group for row in rows)
+            for group in GROUPS
+        },
+        "validations_by_group": _rates_by(rows, "group"),
+        "validations_by_known_delivery_state": _rates_by(
+            rows,
+            "known_delivery_state",
+        ),
+        "scores_by_group": _scores_by(rows, "group"),
+        "scores_by_known_delivery_state": _scores_by(
+            rows,
+            "known_delivery_state",
+        ),
+        "response_mode_by_group": _counts_by(rows, "group", "response_mode"),
+        "history_summary": _history_summary(rows),
+        "match_quality": _counts_by(rows, "group", "match_quality").get(
+            "control",
+            {},
+        ),
+        "n_without_eval_result": sum(
+            row.get("eval_result") is None for row in rows
+        ),
+        "rows": rows,
+        "limits": [
+            "The known Drift records are AI-reviewed synthetic development data.",
+            (
+                "A control target has no known Drift for its Persona. This is not "
+                "human ground truth."
+            ),
+            (
+                "Active and ended Drift records can require different Coach Digest "
+                "responses."
+            ),
+            (
+                "Specificity and tension honesty can differ by group because a "
+                "control response has no known Drift to describe."
+            ),
+        ],
+    }
+
+
+def _render_score_table(
+    lines: list[str],
+    scores: dict[str, dict[str, dict[str, object]]],
+    groups: tuple[str, ...],
+) -> None:
+    lines += [
+        "| Dimension | " + " | ".join(groups) + " |",
+        "| --- | " + " | ".join("---:" for _ in groups) + " |",
+    ]
+    for dimension in SCORE_DIMENSIONS:
+        cells: list[str] = []
+        for group in groups:
+            cell = scores.get(group, {}).get(dimension)
+            cells.append(
+                f"{cell['mean']:.2f} (n={cell['n']})" if cell is not None else "—"
+            )
+        lines.append(f"| {dimension} | " + " | ".join(cells) + " |")
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Coach Digest Drift and Control Comparison",
+        "",
+        "**Source:** Coach Digest Validations and Coach Digest Evals. These "
+        "results are not human validation.",
+        "",
+        f"- Coach Digest responses: {report['n_rows']}",
+        f"- Drift group: {report['n_by_group'].get('drift', 0)}",
+        f"- Control group: {report['n_by_group'].get('control', 0)}",
+        f"- Generator model: `{report.get('generator_model') or 'unrecorded'}`",
+        f"- Evaluator model: `{report.get('evaluator_model') or 'unrecorded'}`",
+        "- Cross-provider AI review: "
+        + (
+            "yes"
+            if report.get("cross_provider") is True
+            else "no"
+            if report.get("cross_provider") is False
+            else "unrecorded"
+        ),
+        f"- Responses without AI review: {report['n_without_eval_result']}",
+        "",
+        "## Coach Digest Validation pass rate",
+        "",
+        "| Check | Drift group | Control group |",
+        "| --- | --- | --- |",
+    ]
+    rates = report["validations_by_group"]
+    for name in CHECK_NAMES:
+        cells: list[str] = []
+        for group in GROUPS:
+            cell = rates.get(group, {}).get(name)
+            if cell is None:
+                cells.append("—")
+                continue
+            low, high = cell["ci95"]
+            cells.append(
+                f"{cell['rate']:.0%} ({cell['passed']}/{cell['total']}; "
+                f"95% interval {low:.0%}-{high:.0%})"
+            )
+        lines.append(f"| {name} | {cells[0]} | {cells[1]} |")
+
+    lines += ["", "## Coach Digest Eval mean by group", ""]
+    _render_score_table(lines, report["scores_by_group"], GROUPS)
+    state_groups = tuple(sorted(report["scores_by_known_delivery_state"]))
+    if state_groups:
+        lines += ["", "## Coach Digest Eval mean by known Drift state", ""]
+        _render_score_table(
+            lines,
+            report["scores_by_known_delivery_state"],
+            state_groups,
+        )
+
+    lines += [
+        "",
+        "## Input history by group",
+        "",
+        "| Group | Responses | Mean Journal Entries | Mean evidence items | "
+        "Mean reviewed weeks |",
+        "| --- | ---: | ---: | ---: | ---: |",
+    ]
+    history = report["history_summary"]
+    for group in GROUPS:
+        row = history.get(group)
+        if row is None:
+            continue
+        lines.append(
+            f"| {group} | {row['n']} | {row['mean_n_entries']:.2f} | "
+            f"{row['mean_n_evidence']:.2f} | "
+            f"{row['mean_reviewed_week_count']:.2f} |"
+        )
+
+    lines += ["", "## Response mode by group", ""]
+    for group in GROUPS:
+        modes = report["response_mode_by_group"].get(group, {})
+        value = ", ".join(
+            f"{mode}={count}" for mode, count in sorted(modes.items())
+        )
+        lines.append(f"- {group}: {value or 'none'}")
+
+    match_quality = report.get("match_quality") or {}
+    if match_quality:
+        value = ", ".join(
+            f"{quality}={count}"
+            for quality, count in sorted(match_quality.items())
+        )
+        lines += ["", "## Control match quality", "", value]
+
+    lines += ["", "## Limits", ""]
+    if report.get("self_evaluation") is True:
+        lines += [
+            "- One provider model generated and evaluated the responses. "
+            "Correlated errors can make this AI review too favorable."
+        ]
+    lines += [f"- {limit}" for limit in report["limits"]]
+    return "\n".join(lines) + "\n"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare Coach Digest results for Drift and control targets."
+    )
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--eval-metrics", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    manifest = json.loads(args.manifest.read_text())
+    eval_metrics = json.loads(args.eval_metrics.read_text())
+    report = build_report(
+        manifest,
+        eval_metrics,
+        manifest_source=str(args.manifest),
+        eval_source=str(args.eval_metrics),
+    )
+    if args.out is not None:
+        args.out.mkdir(parents=True, exist_ok=True)
+        (args.out / "metrics.json").write_text(json.dumps(report, indent=2) + "\n")
+        (args.out / "report.md").write_text(render_markdown(report))
+    print(render_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/evals/coach_narrative_judge.py
+++ b/src/evals/coach_narrative_judge.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
@@ -30,11 +29,11 @@ from pydantic import BaseModel, Field, ValidationError
 
 from prompts import load_prompt
 from src.coach.llm_client import (
-    DEFAULT_GEMINI_MODEL,
     DEFAULT_OPENAI_MODEL,
     DEFAULT_OPENAI_REASONING_EFFORT,
     OPENAI_LUNA_PRICING_SOURCE,
     build_llm_complete,
+    resolve_coach_model,
     summarize_llm_call_metrics,
 )
 from src.coach.schemas import CoachNarrative, LLMCallMetrics, WeeklyDigest
@@ -140,6 +139,7 @@ class JudgeReport:
     judge_model: str
     n_scored: int
     judge_reasoning_effort: str = DEFAULT_OPENAI_REASONING_EFFORT
+    generator_model: str | None = None
     means: dict[str, float] = field(default_factory=dict)
     pct_ge_4: dict[str, float] = field(default_factory=dict)
     question_open_rate: float = 0.0
@@ -147,6 +147,14 @@ class JudgeReport:
     n_failed: int = 0
     call_metrics: list[LLMCallMetrics] = field(default_factory=list)
     sample_results: list[dict[str, object]] = field(default_factory=list)
+
+    @property
+    def self_evaluation(self) -> bool:
+        """Return whether one provider model generated and evaluated the response."""
+        return (
+            self.generator_model is not None
+            and self.generator_model == self.judge_model
+        )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -159,9 +167,13 @@ class JudgeReport:
             ),
             "judge_model": self.judge_model,
             "judge_reasoning_effort": self.judge_reasoning_effort,
+            "generator_model": self.generator_model,
+            "self_evaluation": self.self_evaluation,
             "same_model_review_limitation": (
-                "Luna-none generated and evaluated these responses. Correlated "
-                "errors can make the AI review too favorable."
+                "One provider model generated and evaluated these responses. "
+                "Correlated errors can make the AI review too favorable."
+                if self.self_evaluation
+                else None
             ),
             "n_scored": self.n_scored,
             "n_failed": self.n_failed,
@@ -190,7 +202,12 @@ class JudgeReport:
             "api_calls": [
                 metric.model_dump(mode="json") for metric in self.call_metrics
             ],
-            "pricing_source": OPENAI_LUNA_PRICING_SOURCE,
+            "pricing_source": (
+                OPENAI_LUNA_PRICING_SOURCE
+                if self.judge_model
+                in {DEFAULT_OPENAI_MODEL, f"openai:{DEFAULT_OPENAI_MODEL}"}
+                else None
+            ),
             "cost_note": (
                 "Calculated from response token usage and published standard-tier "
                 "rates. This is not an OpenAI billing export."
@@ -204,6 +221,7 @@ def aggregate_verdicts(
     call_metrics: list[LLMCallMetrics] | None = None,
     sample_labels: list[str] | None = None,
     judge_reasoning_effort: str = DEFAULT_OPENAI_REASONING_EFFORT,
+    generator_model: str | None = None,
 ) -> JudgeReport:
     """Aggregate per-narrative verdicts into a report; None verdicts count as failed."""
     scored = [v for v in verdicts if v is not None]
@@ -251,6 +269,7 @@ def aggregate_verdicts(
         judge_model=judge_model,
         n_scored=n,
         judge_reasoning_effort=judge_reasoning_effort,
+        generator_model=generator_model,
         means=means,
         pct_ge_4=pct_ge_4,
         question_open_rate=question_open_rate,
@@ -273,8 +292,15 @@ def render_markdown(report: JudgeReport) -> str:
         "",
         f"- Evaluator model: `{report.judge_model}`",
         f"- Evaluator reasoning effort: `{report.judge_reasoning_effort}`",
-        "- Same-model-review limitation: Luna-none generated and evaluated the "
-        "responses. Correlated errors can make this AI review too favorable.",
+        f"- Generator model: `{report.generator_model or 'unrecorded'}`",
+    ]
+    if report.self_evaluation:
+        lines += [
+            "- Same-model-review limitation: one provider model generated and "
+            "evaluated the responses. Correlated errors can make this AI review "
+            "too favorable.",
+        ]
+    lines += [
         f"- Scored: {report.n_scored}",
         f"- Failed (no valid verdict): {report.n_failed}",
         f"- Flagged for human review (any dimension < {REVIEW_THRESHOLD}): "
@@ -297,8 +323,18 @@ def render_markdown(report: JudgeReport) -> str:
             f"{float(usage['median_latency_seconds'] or 0):.3f}s / "
             f"{float(usage['max_latency_seconds'] or 0):.3f}s"
         ),
-        "- Cost basis: response token usage and published standard-tier Luna "
-        f"rates ([source]({OPENAI_LUNA_PRICING_SOURCE})); not a billing export",
+    ]
+    if report.judge_model in {
+        DEFAULT_OPENAI_MODEL,
+        f"openai:{DEFAULT_OPENAI_MODEL}",
+    }:
+        lines += [
+            "- Cost basis: response token usage and published standard-tier Luna "
+            f"rates ([source]({OPENAI_LUNA_PRICING_SOURCE})); not a billing export",
+        ]
+    else:
+        lines += ["- Cost basis: unavailable for the selected evaluator model"]
+    lines += [
         "",
         "| Dimension | Mean | Target | Meets | % ≥ 4 |",
         "| --- | --- | --- | --- | --- |",
@@ -399,6 +435,42 @@ def _load_manifest(manifest_path: Path) -> list[tuple[WeeklyDigest, CoachNarrati
     return pairs
 
 
+def _load_generator_model(manifest_path: Path) -> str | None:
+    """Return one recorded generator model, or ``None`` when records disagree."""
+    items = json.loads(manifest_path.read_text())
+    recorded: set[str] = set()
+    for item in items:
+        model = item.get("generator_model")
+        provenance = item.get("provenance") or {}
+        generation = provenance.get("generation") or {}
+        contract = generation.get("model_contract") or {}
+        if not model and contract.get("provider") and contract.get("model"):
+            model = f"{contract['provider']}:{contract['model']}"
+        if not model and provenance.get("coach_provider") and provenance.get(
+            "coach_model"
+        ):
+            model = f"{provenance['coach_provider']}:{provenance['coach_model']}"
+        if model:
+            recorded.add(str(model))
+    return next(iter(recorded)) if len(recorded) == 1 else None
+
+
+def _load_sample_labels(manifest_path: Path) -> list[str]:
+    """Load stable target labels with a Persona-week compatibility fallback."""
+    items = json.loads(manifest_path.read_text())
+    labels: list[str] = []
+    for item in items:
+        digest = item["digest"]
+        target = item.get("target") or {}
+        labels.append(
+            str(
+                target.get("target_id")
+                or f"{digest['persona_id']}:{digest['week_end']}"
+            )
+        )
+    return labels
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run Coach Digest Evals with an AI evaluator."
@@ -411,6 +483,20 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--out", type=Path, default=None)
     parser.add_argument(
+        "--judge-provider",
+        choices=["openai", "gemini"],
+        default=None,
+        help=(
+            "Evaluator provider. A provider that differs from the configured "
+            "provider uses its own default model."
+        ),
+    )
+    parser.add_argument(
+        "--judge-model",
+        default=None,
+        help="Evaluator model. This overrides the selected provider's default.",
+    )
+    parser.add_argument(
         "--execute",
         action="store_true",
         help="Authorize paid evaluator LLM calls. Without it, this prints the plan "
@@ -420,39 +506,41 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
     args = _build_parser().parse_args(argv)
     pairs = _load_manifest(args.manifest)
+    judge_provider, judge_model_name = resolve_coach_model(
+        provider=args.judge_provider,
+        model=args.judge_model,
+    )
+    judge_model = f"{judge_provider}:{judge_model_name}"
 
     if not args.execute:
         print(
             f"[dry run] Would evaluate {len(pairs)} Coach Digest response(s) "
-            "with the "
-            "configured provider. Re-run with --execute to make paid calls."
+            f"with {judge_model}. Re-run with --execute to make paid calls."
         )
         return 0
 
-    load_dotenv()
     call_metrics: list[LLMCallMetrics] = []
-    llm_complete = build_llm_complete(call_metrics=call_metrics)
+    llm_complete = build_llm_complete(
+        provider=args.judge_provider,
+        model=args.judge_model,
+        call_metrics=call_metrics,
+    )
     if llm_complete is None:
         print("No evaluator provider available (missing API key). Aborting.")
         return 1
 
-    provider = os.environ.get("TWINKL_COACH_PROVIDER", "openai").strip().lower()
-    default_model = (
-        DEFAULT_GEMINI_MODEL if provider == "gemini" else DEFAULT_OPENAI_MODEL
-    )
-    judge_model = os.environ.get("TWINKL_COACH_MODEL", default_model)
     verdicts = asyncio.run(_run_sample(pairs, llm_complete, call_metrics))
-    sample_labels = [
-        f"{digest.persona_id}:{digest.week_end}" for digest, _narrative in pairs
-    ]
+    sample_labels = _load_sample_labels(args.manifest)
     report = aggregate_verdicts(
         verdicts,
         judge_model=judge_model,
         call_metrics=call_metrics,
         sample_labels=sample_labels,
         judge_reasoning_effort=DEFAULT_OPENAI_REASONING_EFFORT,
+        generator_model=_load_generator_model(args.manifest),
     )
 
     if args.out is not None:

--- a/tests/coach/test_llm_client.py
+++ b/tests/coach/test_llm_client.py
@@ -8,10 +8,13 @@ import pytest
 from openai.types.responses.response_usage import ResponseUsage
 
 from src.coach.llm_client import (
+    DEFAULT_GEMINI_MODEL,
+    DEFAULT_OPENAI_MODEL,
     DEFAULT_OPENAI_REASONING_EFFORT,
     DEFAULT_OPENAI_SERVICE_TIER,
     build_llm_complete,
     calculate_openai_cost_usd,
+    resolve_coach_model,
     summarize_llm_call_metrics,
 )
 from src.coach.schemas import LLMCallMetrics
@@ -28,6 +31,31 @@ def test_calculate_openai_cost_includes_cache_reads_and_writes():
     )
 
     assert cost == pytest.approx(0.000432)
+
+
+def test_explicit_provider_uses_provider_default_model(monkeypatch):
+    monkeypatch.setenv("TWINKL_COACH_PROVIDER", "gemini")
+    monkeypatch.setenv("TWINKL_COACH_MODEL", "gemini-custom")
+
+    assert resolve_coach_model() == ("gemini", "gemini-custom")
+    assert resolve_coach_model(provider="openai") == (
+        "openai",
+        DEFAULT_OPENAI_MODEL,
+    )
+    assert resolve_coach_model(provider="gemini") == (
+        "gemini",
+        "gemini-custom",
+    )
+    assert resolve_coach_model(provider="openai", model="openai-custom") == (
+        "openai",
+        "openai-custom",
+    )
+
+    monkeypatch.delenv("TWINKL_COACH_MODEL")
+    assert resolve_coach_model(provider="gemini") == (
+        "gemini",
+        DEFAULT_GEMINI_MODEL,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/coach/test_weekly_drift_runtime.py
+++ b/tests/coach/test_weekly_drift_runtime.py
@@ -199,6 +199,53 @@ async def test_runtime_does_not_attach_an_invalid_coach_response(tmp_path: Path)
     assert "coach_diagnostic" not in stored_digest
 
 
+@pytest.mark.asyncio
+async def test_offline_evaluation_can_attach_a_failed_coach_response(tmp_path: Path):
+    wrangled_dir = tmp_path / "wrangled"
+    wrangled_dir.mkdir()
+    _write_wrangled(wrangled_dir / "persona_deadbeef.md")
+    reviewer = OpenAIWeeklyDriftReviewer(
+        client=SimpleNamespace(responses=_SequencedResponses())
+    )
+
+    async def invalid_coach(
+        _prompt: str,
+        _response_format: dict | None,
+        _instructions: str | None = None,
+    ) -> str:
+        return json.dumps(
+            {
+                "weekly_mirror": (
+                    'You wrote "Called my sister and protected the evening for '
+                    'family," and this proves improvement.'
+                ),
+                "tension_explanation": (
+                    "The latest choice shows that the earlier concern is now fixed."
+                ),
+                "reflective_question": (
+                    "What helped you make that change and keep it going next week?"
+                ),
+            }
+        )
+
+    digest, paths = await run_weekly_drift_coach_cycle(
+        persona_id="deadbeef",
+        wrangled_dir=wrangled_dir,
+        output_dir=tmp_path / "exports",
+        parquet_path=tmp_path / "weekly_digests.parquet",
+        reviewer=reviewer,
+        coach_llm_complete=invalid_coach,
+        attach_failed_validation=True,
+    )
+
+    assert digest.coach_narrative is not None
+    assert digest.validation is not None
+    assert digest.validation.all_passed is False
+    stored_digest = json.loads(Path(paths["digest_json_path"]).read_text())
+    assert stored_digest["coach_narrative"] is not None
+    assert stored_digest["validation"] is not None
+
+
 def _write_onboarding_profile(path: Path, **overrides) -> None:
     payload = {
         "schema_version": 4,

--- a/tests/evals/test_coach_drift_control_report.py
+++ b/tests/evals/test_coach_drift_control_report.py
@@ -1,0 +1,191 @@
+"""Tests for the Coach Digest Drift/control comparison report."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.evals.coach_drift_control_report import (
+    build_report,
+    render_markdown,
+    wilson_interval,
+)
+
+CHECK_NAMES = (
+    "groundedness",
+    "non_circularity",
+    "value_leakage",
+    "state_claims",
+    "length",
+)
+
+
+def _entry(
+    target_id: str,
+    group: str,
+    *,
+    grounded: bool,
+    delivery_state: str | None = None,
+    n_entries: int = 8,
+) -> dict:
+    checks = [
+        {
+            "name": name,
+            "passed": grounded if name == "groundedness" else True,
+            "details": "",
+        }
+        for name in CHECK_NAMES
+    ]
+    return {
+        "digest": {
+            "persona_id": target_id,
+            "week_end": "2025-06-08",
+            "response_mode": "active_drift" if group == "drift" else "stable",
+            "n_entries": n_entries,
+            "evidence": [{"excerpt": "x"}, {"excerpt": "y"}],
+        },
+        "narrative": {"weekly_mirror": "m"},
+        "validation": {"all_passed": grounded, "checks": checks},
+        "generator_model": "openai:model-one",
+        "target": {
+            "target_id": target_id,
+            "group": group,
+            "delivery_state": delivery_state,
+            "match_quality": "exact",
+            "reviewed_week_count": 4,
+        },
+    }
+
+
+def _eval_result(target_id: str, specificity: int) -> dict:
+    return {
+        "sample_id": target_id,
+        "status": "scored",
+        "correctness": 4,
+        "specificity": specificity,
+        "non_prescriptive_tone": 5,
+        "tension_honesty": 4,
+        "needs_review": False,
+        "justification": "ok",
+    }
+
+
+def test_wilson_interval_brackets_rate_and_stays_in_range():
+    low, high = wilson_interval(5, 10)
+    assert low < 0.5 < high
+    assert 0.0 <= low and high <= 1.0
+
+    low, high = wilson_interval(4, 4)
+    assert high == 1.0
+    assert low < 1.0
+    assert wilson_interval(0, 0) == (0.0, 0.0)
+
+
+def test_report_compares_validations_scores_and_known_drift_state():
+    manifest = [
+        _entry("d1", "drift", grounded=True, delivery_state="active"),
+        _entry("d2", "drift", grounded=True, delivery_state="ended"),
+        _entry("c1", "control", grounded=False),
+        _entry("c2", "control", grounded=False),
+    ]
+    eval_metrics = {
+        "judge_model": "gemini:model-two",
+        "sample_results": [
+            _eval_result("d1", 4),
+            _eval_result("d2", 4),
+            _eval_result("c1", 2),
+            _eval_result("c2", 2),
+        ]
+    }
+
+    report = build_report(manifest, eval_metrics)
+
+    assert report["n_by_group"] == {"drift": 2, "control": 2}
+    assert report["generator_model"] == "openai:model-one"
+    assert report["evaluator_model"] == "gemini:model-two"
+    assert report["cross_provider"] is True
+    assert report["self_evaluation"] is False
+    drift = report["validations_by_group"]["drift"]["groundedness"]
+    control = report["validations_by_group"]["control"]["groundedness"]
+    assert drift["passed"] == 2 and drift["rate"] == 1.0
+    assert control["passed"] == 0 and control["rate"] == 0.0
+    assert len(drift["ci95"]) == 2
+    assert report["scores_by_group"]["drift"]["specificity"]["mean"] == 4.0
+    assert report["scores_by_group"]["control"]["specificity"]["mean"] == 2.0
+    assert report["scores_by_known_delivery_state"]["active"]["correctness"][
+        "mean"
+    ] == 4.0
+    assert report["n_without_eval_result"] == 0
+
+
+def test_report_recomputes_all_passed_and_exposes_history_inputs():
+    manifest = [
+        _entry("d1", "drift", grounded=True, n_entries=12),
+        _entry("c1", "control", grounded=False, n_entries=4),
+    ]
+    manifest[1]["validation"]["all_passed"] = True
+
+    report = build_report(manifest, {"sample_results": []})
+
+    rows = {row["sample_id"]: row for row in report["rows"]}
+    assert rows["d1"]["all_passed"] is True
+    assert rows["c1"]["all_passed"] is False
+    assert report["history_summary"]["drift"]["mean_n_entries"] == 12
+    assert report["history_summary"]["control"]["mean_n_entries"] == 4
+    assert report["n_without_eval_result"] == 2
+
+
+def test_report_rejects_duplicate_target_ids():
+    manifest = [
+        _entry("d1", "drift", grounded=True),
+        _entry("d1", "drift", grounded=True),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate manifest target"):
+        build_report(manifest, {"sample_results": []})
+
+
+def test_report_rejects_eval_results_from_another_manifest():
+    manifest = [_entry("d1", "drift", grounded=True)]
+    eval_metrics = {"sample_results": [_eval_result("another-target", 4)]}
+
+    with pytest.raises(ValueError, match="do not match the manifest"):
+        build_report(manifest, eval_metrics)
+
+
+def test_report_rejects_a_different_generator_model():
+    manifest = [_entry("d1", "drift", grounded=True)]
+    eval_metrics = {
+        "generator_model": "openai:different-model",
+        "sample_results": [_eval_result("d1", 4)],
+    }
+
+    with pytest.raises(ValueError, match="different generator model"):
+        build_report(manifest, eval_metrics)
+
+
+def test_report_rejects_multiple_manifest_generator_models():
+    manifest = [
+        _entry("d1", "drift", grounded=True),
+        _entry("c1", "control", grounded=True),
+    ]
+    manifest[1]["generator_model"] = "openai:model-two"
+
+    with pytest.raises(ValueError, match="multiple Coach Digest generator"):
+        build_report(manifest, {"sample_results": []})
+
+
+def test_markdown_states_sources_and_limits():
+    report = build_report(
+        [_entry("d1", "drift", grounded=True, delivery_state="active")],
+        {"sample_results": []},
+    )
+    markdown = render_markdown(report)
+
+    assert "not human validation" in markdown.lower()
+    assert "AI-reviewed synthetic development data" in markdown
+    assert "Input history by group" in markdown
+    assert "Cross-provider AI review: unrecorded" in markdown
+    assert "95% interval" in markdown
+    assert json.loads(json.dumps(report))["n_rows"] == 1

--- a/tests/evals/test_coach_narrative_judge.py
+++ b/tests/evals/test_coach_narrative_judge.py
@@ -16,8 +16,11 @@ from src.coach.schemas import (
 )
 from src.evals.coach_narrative_judge import (
     JudgeVerdict,
+    _load_generator_model,
+    _load_sample_labels,
     aggregate_verdicts,
     judge_narrative,
+    main,
     render_judge_prompt,
     render_markdown,
 )
@@ -364,3 +367,77 @@ def test_report_renders_per_response_scores_and_justifications():
     assert "deadbeef:2025-01-07 | 4 | 5 | 5 | 4 | pass | no" in markdown
     assert "## Evaluator Justifications" in markdown
     assert "Grounded, specific, and honest about the tension." in markdown
+
+
+def test_report_marks_same_model_review_only_when_models_match():
+    same = aggregate_verdicts(
+        [],
+        judge_model="openai:gpt-test",
+        generator_model="openai:gpt-test",
+    )
+    independent = aggregate_verdicts(
+        [],
+        judge_model="gemini:gemini-test",
+        generator_model="openai:gpt-test",
+    )
+
+    assert same.self_evaluation is True
+    assert same.to_dict()["same_model_review_limitation"] is not None
+    assert "Same-model-review limitation" in render_markdown(same)
+    assert independent.self_evaluation is False
+    assert independent.to_dict()["same_model_review_limitation"] is None
+    assert "Same-model-review limitation" not in render_markdown(independent)
+
+
+def test_manifest_provenance_supplies_generator_model_and_target_label(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "digest": _digest().model_dump(mode="json"),
+                    "narrative": _narrative().model_dump(mode="json"),
+                    "target": {"target_id": "drift-target-1"},
+                    "provenance": {
+                        "generation": {
+                            "model_contract": {
+                                "provider": "openai",
+                                "model": "gpt-test",
+                            }
+                        }
+                    },
+                }
+            ]
+        )
+    )
+
+    assert _load_generator_model(path) == "openai:gpt-test"
+    assert _load_sample_labels(path) == ["drift-target-1"]
+
+
+def test_main_dry_run_reports_explicit_cross_provider_model(tmp_path, capsys):
+    path = tmp_path / "manifest.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "digest": _digest().model_dump(mode="json"),
+                    "narrative": _narrative().model_dump(mode="json"),
+                }
+            ]
+        )
+    )
+
+    result = main(
+        [
+            "--manifest",
+            str(path),
+            "--judge-provider",
+            "gemini",
+            "--judge-model",
+            "gemini-test",
+        ]
+    )
+
+    assert result == 0
+    assert "gemini:gemini-test" in capsys.readouterr().out

--- a/tests/experiments/test_run_coach_drift_control_eval.py
+++ b/tests/experiments/test_run_coach_drift_control_eval.py
@@ -1,0 +1,375 @@
+"""Tests for the Drift and control Coach Digest study runner."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "experiments"
+    / "run_coach_drift_control_eval.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "run_coach_drift_control_eval",
+    _MODULE_PATH,
+)
+assert _spec is not None and _spec.loader is not None
+driver = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = driver
+_spec.loader.exec_module(driver)
+
+
+def _write_wrangled(path: Path, dates: list[str]) -> None:
+    persona_id = path.stem.replace("persona_", "")
+    lines = [
+        f"# Persona {persona_id}: Casey",
+        "",
+        "## Profile",
+        f"- **Persona ID:** {persona_id}",
+        "- **Name:** Casey",
+        "- **Age:** 25-34",
+        "- **Profession:** Engineer",
+        "- **Culture:** Singaporean",
+        "- **Core Values:** Benevolence",
+        "- **Bio:** Study runner test Persona.",
+        "",
+        "---",
+        "",
+    ]
+    for index, day in enumerate(dates):
+        lines += [
+            f"## Entry {index} - {day}",
+            "",
+            "A day of work and family.",
+            "",
+            "---",
+            "",
+        ]
+    path.write_text("\n".join(lines))
+
+
+@pytest.fixture
+def sample_inputs(tmp_path: Path) -> dict[str, Path]:
+    wrangled = tmp_path / "wrangled"
+    wrangled.mkdir()
+    _write_wrangled(
+        wrangled / "persona_d1.md",
+        ["2025-06-02", "2025-06-09", "2025-06-16"],
+    )
+    _write_wrangled(
+        wrangled / "persona_d2.md",
+        ["2025-07-07", "2025-07-14"],
+    )
+    for name in ("c1", "c2", "c3"):
+        _write_wrangled(
+            wrangled / f"persona_{name}.md",
+            ["2025-06-02", "2025-06-09", "2025-06-16"],
+        )
+
+    episodes_path = tmp_path / "episodes.parquet"
+    pl.DataFrame(
+        [
+            {
+                "episode_id": "e1",
+                "persona_id": "d1",
+                "dimension": "benevolence",
+                "confirmation_date": "2025-06-09",
+                "delivery_state": "ended",
+            },
+            {
+                "episode_id": "e2",
+                "persona_id": "d2",
+                "dimension": "security",
+                "confirmation_date": "2025-07-14",
+                "delivery_state": "active",
+            },
+        ]
+    ).write_parquet(episodes_path)
+
+    cases_path = tmp_path / "cases.parquet"
+    pl.DataFrame(
+        [
+            {
+                "persona_id": "d1",
+                "dimension": "benevolence",
+                "historical_split": "training",
+                "entry_count": 8,
+                "has_drift": True,
+            },
+            {
+                "persona_id": "d2",
+                "dimension": "security",
+                "historical_split": "training",
+                "entry_count": 8,
+                "has_drift": True,
+            },
+            {
+                "persona_id": "c1",
+                "dimension": "benevolence",
+                "historical_split": "training",
+                "entry_count": 8,
+                "has_drift": False,
+            },
+            {
+                "persona_id": "c2",
+                "dimension": "security",
+                "historical_split": "training",
+                "entry_count": 8,
+                "has_drift": False,
+            },
+            {
+                "persona_id": "c3",
+                "dimension": "tradition",
+                "historical_split": "retired",
+                "entry_count": 3,
+                "has_drift": False,
+            },
+        ]
+    ).write_parquet(cases_path)
+    return {
+        "wrangled": wrangled,
+        "episodes": episodes_path,
+        "cases": cases_path,
+    }
+
+
+def test_drift_targets_use_the_confirmation_week(sample_inputs):
+    targets = driver.load_drift_targets(
+        sample_inputs["episodes"],
+        sample_inputs["cases"],
+        sample_inputs["wrangled"],
+    )
+
+    by_persona = {target.persona_id: target for target in targets}
+    assert by_persona["d1"].target_id == "drift:e1"
+    assert by_persona["d1"].end_date == "2025-06-09"
+    assert by_persona["d1"].reviewed_week_count == 2
+    assert by_persona["d1"].delivery_state == "ended"
+
+
+def test_controls_are_deterministic_and_exclude_drift_personas(sample_inputs):
+    def run() -> list[driver.EvalTarget]:
+        drift_targets = driver.load_drift_targets(
+            sample_inputs["episodes"],
+            sample_inputs["cases"],
+            sample_inputs["wrangled"],
+        )
+        return driver.sample_control_targets(
+            sample_inputs["cases"],
+            sample_inputs["episodes"],
+            drift_targets,
+            sample_inputs["wrangled"],
+            seed=7,
+        )
+
+    first = run()
+    second = run()
+    assert [asdict(target) for target in first] == [
+        asdict(target) for target in second
+    ]
+    assert {target.persona_id for target in first}.isdisjoint({"d1", "d2"})
+    assert len({target.persona_id for target in first}) == len(first)
+    assert all(target.group == "control" for target in first)
+    assert all(target.target_id.startswith("control:") for target in first)
+    drift_targets = run_drift_targets(sample_inputs)
+    by_episode = {target.matched_to: target for target in first}
+    for drift_target in drift_targets:
+        control = by_episode[drift_target.episode_id]
+        assert (
+            abs(
+                control.reviewed_week_count
+                - drift_target.reviewed_week_count
+            )
+            <= 1
+        )
+
+
+def run_drift_targets(sample_inputs: dict[str, Path]) -> list[driver.EvalTarget]:
+    return driver.load_drift_targets(
+        sample_inputs["episodes"],
+        sample_inputs["cases"],
+        sample_inputs["wrangled"],
+    )
+
+
+def test_build_targets_limit_applies_to_each_group(sample_inputs):
+    targets = driver.build_targets(
+        episodes_path=sample_inputs["episodes"],
+        case_outcomes_path=sample_inputs["cases"],
+        wrangled_dir=sample_inputs["wrangled"],
+        group="both",
+        seed=7,
+        limit=1,
+    )
+
+    assert sum(target.group == "drift" for target in targets) == 1
+    assert sum(target.group == "control" for target in targets) == 1
+    assert len({target.target_id for target in targets}) == len(targets)
+
+
+def test_limit_must_be_positive():
+    assert driver._positive_int("1") == 1
+    with pytest.raises(argparse.ArgumentTypeError, match="at least 1"):
+        driver._positive_int("0")
+
+
+def test_target_output_directory_does_not_use_untrusted_target_text(tmp_path):
+    output = driver._target_output_dir(tmp_path, "../../outside")
+
+    assert output.parent == tmp_path
+    assert output.name.startswith("target_")
+    assert "outside" not in output.name
+
+
+def test_resume_preserves_other_targets_and_rejects_changed_inputs(tmp_path):
+    path = tmp_path / "targets.json"
+    existing = {
+        "schema_version": "coach-digest-drift-control-targets-v1",
+        "seed": 7,
+        "sources": {"source": "one"},
+        "targets": [{"target_id": "drift:e1", "group": "drift"}],
+    }
+    path.write_text(json.dumps(existing))
+    control = {
+        **existing,
+        "targets": [{"target_id": "control:e1:c1", "group": "control"}],
+    }
+
+    merged = driver.merge_target_catalog(path, control, resume=True)
+
+    assert [item["target_id"] for item in merged["targets"]] == [
+        "control:e1:c1",
+        "drift:e1",
+    ]
+    changed = {**control, "seed": 8}
+    with pytest.raises(ValueError, match="different schema, inputs, or seed"):
+        driver.merge_target_catalog(path, changed, resume=True)
+
+
+def test_resume_rejects_duplicate_manifest_target_ids(tmp_path):
+    path = tmp_path / "manifest.json"
+    item = {"target": {"target_id": "drift:e1"}}
+    path.write_text(json.dumps([item, item]))
+
+    with pytest.raises(ValueError, match="Duplicate manifest target ID"):
+        driver._manifest_index(path, resume=True)
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_targets_that_are_already_in_the_manifest(tmp_path):
+    target = driver.EvalTarget(
+        target_id="drift:e1",
+        persona_id="d1",
+        end_date="2025-06-09",
+        group="drift",
+        historical_split="training",
+        entry_count=8,
+        reviewed_week_count=2,
+    )
+    existing = {target.target_id: {"target": asdict(target)}}
+
+    result = await driver.generate_missing_targets(
+        [target],
+        existing,
+        parquet_path=tmp_path / "unused.parquet",
+        output_dir=tmp_path / "unused-output",
+        wrangled_dir=tmp_path / "unused-wrangled",
+    )
+
+    assert result is existing
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_a_different_generator_model(tmp_path, monkeypatch):
+    target = driver.EvalTarget(
+        target_id="drift:e2",
+        persona_id="d2",
+        end_date="2025-06-09",
+        group="drift",
+        historical_split="training",
+        entry_count=8,
+        reviewed_week_count=2,
+    )
+    existing = {
+        "drift:e1": {
+            "generator_model": "openai:model-one",
+            "target": {"target_id": "drift:e1"},
+        }
+    }
+    monkeypatch.setattr(
+        driver,
+        "resolve_coach_model",
+        lambda: ("gemini", "model-two"),
+    )
+
+    with pytest.raises(ValueError, match="different Coach Digest generator"):
+        await driver.generate_missing_targets(
+            [target],
+            existing,
+            parquet_path=tmp_path / "unused.parquet",
+            output_dir=tmp_path / "unused-output",
+            wrangled_dir=tmp_path / "unused-wrangled",
+        )
+
+
+@pytest.mark.asyncio
+async def test_completed_target_is_saved_before_a_later_failure(
+    tmp_path,
+    monkeypatch,
+):
+    targets = [
+        driver.EvalTarget(
+            target_id=f"drift:e{index}",
+            persona_id=f"d{index}",
+            end_date="2025-06-09",
+            group="drift",
+            historical_split="training",
+            entry_count=8,
+            reviewed_week_count=2,
+        )
+        for index in (1, 2)
+    ]
+    calls = 0
+
+    async def runtime(**_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("later target failed")
+        return object(), {}
+
+    monkeypatch.setattr(driver, "build_llm_complete", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        driver,
+        "resolve_coach_model",
+        lambda: ("openai", "model-one"),
+    )
+    monkeypatch.setattr(driver, "run_weekly_drift_coach_cycle", runtime)
+    monkeypatch.setattr(
+        driver,
+        "_manifest_entry",
+        lambda _digest, target, *_args: {"target": asdict(target)},
+    )
+    manifest_path = tmp_path / "manifest.json"
+
+    with pytest.raises(RuntimeError, match="later target failed"):
+        await driver.generate_missing_targets(
+            targets,
+            {},
+            parquet_path=tmp_path / "unused.parquet",
+            output_dir=tmp_path / "unused-output",
+            wrangled_dir=tmp_path / "unused-wrangled",
+            manifest_path=manifest_path,
+        )
+
+    saved = json.loads(manifest_path.read_text())
+    assert [item["target"]["target_id"] for item in saved] == ["drift:e1"]


### PR DESCRIPTION
cc: @keimiii - i've scoped out your implementation in this PR.

## Summary

- Add explicit provider and model options to Coach Digest Evals.
- Record generator and evaluator models, and report same-model review only when they match.
- Add deterministic Drift/control target selection, safe resume, source hashes, and comparison reporting.
- Keep the current product Coach Digest path unchanged by default.

## Validation

- 110 offline Coach Digest and evaluation tests passed.
- Focused Ruff passed.
- Isolated MyPy passed for the five changed source files.
- The development-data dry run selected 42 Drift targets and 42 matched controls with no provider calls.

No paid evaluation was run. This PR keeps the selected evaluation work from #67 on current main.